### PR TITLE
CloudFormation template will not deploy

### DIFF
--- a/cfn-template.yaml
+++ b/cfn-template.yaml
@@ -72,11 +72,12 @@ Resources:
       Handler: index.handler
       Role: !GetAtt [ AWSElementalMediaServicesRole, Arn ]
       Code:
-        ZipFile:  { "Fn::Join": ["", [
-          "exports.handler = function(event, context, callback){ callback(null, '",
-          !GetAtt [ AWSElementalMediaServicesRole, Arn ],
-          "'); };"
-        ]]}
+        ZipFile:
+          !Join
+            - ''
+            - - "exports.handler = function(event, context, callback){ callback(null, '"
+              - Fn::GetAtt: [AWSElementalMediaServicesRole, Arn]
+              - "'); };"
       Runtime: "nodejs12.x"
       Timeout: "30"
 
@@ -325,17 +326,14 @@ Resources:
                 }
               }
             }
-          - 
-            {
-              mediapackageCreateChannelArn: !GetAtt [ MediaPackageCreateChannel, Arn ], 
-              mediapackageCreateEndpointsArn: !GetAtt [ MediaPackageCreateEndpoints, Arn ],
-              systemsmanagerCreateParametersArn: !GetAtt [ SystemsManagerCreateParameters, Arn ],
-              medialiveAttachRoleArn: !GetAtt [ MediaLiveAttachRole, Arn ],
-              medialiveCreateInputArn: !GetAtt [ MediaLiveCreateInput, Arn ],
-              medialiveCreateChannelArn: !GetAtt [ MediaLiveCreateChannel, Arn ],
-              medialiveDescribeChannelArn: !GetAtt [ MediaLiveDescribeChannel, Arn ],
-              medialiveStartChannelArn: !GetAtt [ MediaLiveStartChannel, Arn ]
-            }
+          - mediapackageCreateChannelArn: !GetAtt MediaPackageCreateChannel.Arn
+            systemsmanagerCreateParametersArn: !GetAtt SystemsManagerCreateParameters.Arn
+            mediapackageCreateEndpointsArn: !GetAtt MediaPackageCreateEndpoints.Arn
+            medialiveAttachRoleArn: !GetAtt MediaLiveAttachRole.Arn
+            medialiveCreateInputArn: !GetAtt MediaLiveCreateInput.Arn
+            medialiveCreateChannelArn: !GetAtt MediaLiveCreateChannel.Arn
+            medialiveDescribeChannelArn: !GetAtt MediaLiveDescribeChannel.Arn
+            medialiveStartChannelArn: !GetAtt MediaLiveStartChannel.Arn
       RoleArn: !GetAtt [ AWSElementalMediaServicesRole, Arn ]
 
   AWSElementalMediaServiceDelete:
@@ -449,16 +447,13 @@ Resources:
                 }
               }
             }
-          - 
-            {
-              mediapackageDeleteChannelArn: !GetAtt [ MediaPackageDeleteChannel, Arn ], 
-              mediapackageDeleteEndpointsArn: !GetAtt [ MediaPackageDeleteEndpoints, Arn ],
-              systemsmanagerDeleteParametersArn: !GetAtt [ SystemsManagerDeleteParameters, Arn ],
-              medialiveDescribeChannelArn: !GetAtt [ MediaLiveDescribeChannel, Arn ],
-              medialiveDescribeInputArn: !GetAtt [ MediaLiveDescribeInput, Arn ],
-              medialiveDeleteInputArn: !GetAtt [ MediaLiveDeleteInput, Arn ],
-              medialiveDeleteChannelArn: !GetAtt [ MediaLiveDeleteChannel, Arn ],
-              medialiveFindChannelArn: !GetAtt [ MediaLiveFindChannel, Arn ],
-              medialiveStopChannelArn: !GetAtt [ MediaLiveStopChannel, Arn ]
-            }
+          - mediapackageDeleteChannelArn: !GetAtt MediaPackageDeleteChannel.Arn
+            mediapackageDeleteEndpointsArn: !GetAtt MediaPackageDeleteEndpoints.Arn
+            systemsmanagerDeleteParametersArn: !GetAtt SystemsManagerDeleteParameters.Arn
+            medialiveDescribeChannelArn: !GetAtt MediaLiveDescribeChannel.Arn
+            medialiveDescribeInputArn: !GetAtt MediaLiveDescribeInput.Arn
+            medialiveDeleteInputArn: !GetAtt MediaLiveDeleteInput.Arn
+            medialiveDeleteChannelArn: !GetAtt MediaLiveDeleteChannel.Arn
+            medialiveFindChannelArn: !GetAtt MediaLiveFindChannel.Arn
+            medialiveStopChannelArn: !GetAtt MediaLiveStopChannel.Arn
       RoleArn: !GetAtt [ AWSElementalMediaServicesRole, Arn ]

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -4,7 +4,7 @@ Once you have gone through the basic setup, and you would like to begin explorin
 
 ## CloudFormation Template
 
-The [CloudFormation Template](../bin/CFnTemplate.yaml) located in this package is meant as a way to bootstrap a given AWS account with the resources and permissions necessary to author media workflows via StepFunctions. __It is not the job of the CFn template to actually author the MediaPackage and MediaLive resources__. 
+The [CloudFormation Template](cfn-template.yaml) located in this package is meant as a way to bootstrap a given AWS account with the resources and permissions necessary to author media workflows via StepFunctions. __It is not the job of the CFn template to actually author the MediaPackage and MediaLive resources__. 
 
 One of the reasons for needing the CloudFormation template to create a Step Function state machine in the first place is because MediaLive and MediaPackage both don't support CloudFormation directly. The workaround for this that we use is to deploy a CloudFormation template with a Step Function state machine that then mimics the behavior of CloudFormation by using composable Lambda functions. This also is a an optimization because it allows more natural level of asyncronous coordination when spinning up a Media Service stack in ways that CloudFormation doesn't support even if MediaLive and MediaPackage were to natively support CloudFormation.
 
@@ -22,7 +22,7 @@ These functions atomically perform operations like creating a MediaPackage endpo
 
 Note that when you make changes to any resource you will need to rebuild and re-deploy the CloudFormation template so that it can pick up your changes. To do so, run the following:
 1. Rebuild the stack\
-`aws cloudformation package --template-file ./bin/CFnTemplate.yaml --s3-bucket <<s3-bucket-name>> --output-template-file cfn-template-out.yaml`
+`aws cloudformation package --template-file cfn-template.yaml --s3-bucket <<s3-bucket-name>> --output-template-file cfn-template-out.yaml`
 2. Re-deploy the stack\
 `aws cloudformation update-stack --stack-name <<stack-name>> --template-body file://cfn-template-out.yaml --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND`
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@
 ## Basic setup
 
 1. Build the CloudFormation template\
-`aws cloudformation package --template-file ./bin/CFnTemplate.yaml --s3-bucket <<s3-bucket-name>> --output-template-file cfn-template-out.yaml`
+`aws cloudformation package --template-file cfn-template.yaml --s3-bucket <<s3-bucket-name>> --output-template-file cfn-template-out.yaml`
 2. Deploy the build CloudFormation template\
 `aws cloudformation create-stack --stack-name <<stack-name>> --template-body file://cfn-template-out.yaml --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND`
 3. All functionality has now been deployed, setup has been completed. Go to the [next section](#creating-medialive-+-mediapackage-video-resources) to learn how to create a video workflow from this stack.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes made to CloudFormation template so that it would deploy based on INSTALL.md instructions. It looks like sections of the previous cloud formation template may have been in JSON format and needed to be converted to YAML.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
